### PR TITLE
Add UnderLine Notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prosemirror-tables": "^1.0.0",
     "prosemirror-utils": "^0.9.6",
     "prosemirror-view": "^1.14.11",
+    "react-icons": "^3.10.0",
     "react-medium-image-zoom": "^3.0.16",
     "react-portal": "^4.2.1",
     "refractor": "^2.10.1",

--- a/src/icons/UnderlineIcon.tsx
+++ b/src/icons/UnderlineIcon.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { FiUnderline } from "react-icons/fi";
+
+type IProps = {
+  size?: string | number;
+  color?: string;
+};
+
+function UnderlineIcon({ size, color }: IProps) {
+  return (
+    <span style={{ color: color }}>
+      <FiUnderline size={size} />
+    </span>
+  );
+}
+
+export default UnderlineIcon;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,6 +54,7 @@ import Highlight from "./marks/Highlight";
 import Italic from "./marks/Italic";
 import Link from "./marks/Link";
 import Strikethrough from "./marks/Strikethrough";
+import UnderLine from "./marks/UnderLine";
 
 // plugins
 import BlockMenuTrigger from "./plugins/BlockMenuTrigger";
@@ -280,6 +281,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         new Placeholder({
           placeholder: this.props.placeholder,
         }),
+        new UnderLine(),
         ...this.props.extensions,
       ],
       this

--- a/src/marks/Italic.ts
+++ b/src/marks/Italic.ts
@@ -20,7 +20,6 @@ export default class Italic extends Mark {
 
   inputRules({ type }) {
     return [
-      markInputRule(/(?:^|[^_])(_([^_]+)_)$/, type),
       markInputRule(/(?:^|[^*])(\*([^*]+)\*)$/, type),
     ];
   }

--- a/src/marks/UnderLine.ts
+++ b/src/marks/UnderLine.ts
@@ -1,0 +1,32 @@
+import Mark from "./Mark";
+import markInputRule from "../lib/markInputRule";
+
+export default class UnderLine extends Mark {
+  get name() {
+    return "underline";
+  }
+
+  get schema() {
+    return {
+      parseDOM: [{ tag: "ins" }],
+      toDOM: () => ["ins"],
+    };
+  }
+
+  inputRules({ type }) {
+    return [markInputRule(/(?:^|[^_])(_([^_]+)_)$/, type)];
+  }
+
+  get toMarkdown() {
+    return {
+      open: "__",
+      close: "__",
+      mixable: true,
+      expelEnclosingWhitespace: true,
+    };
+  }
+
+  parseMarkdown() {
+    return { mark: "ins" };
+  }
+}

--- a/src/menus/formatting.tsx
+++ b/src/menus/formatting.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import {
   BoldIcon,
   CodeIcon,
@@ -9,6 +10,7 @@ import {
   StrikethroughIcon,
   HighlightIcon,
 } from "outline-icons";
+import UnderlineIcon from "../icons/UnderlineIcon";
 import { isInTable } from "prosemirror-tables";
 import { EditorState } from "prosemirror-state";
 import isInList from "../queries/isInList";
@@ -34,6 +36,12 @@ export default function formattingMenuItems(state: EditorState): MenuItem[] {
       tooltip: "Italic",
       icon: ItalicIcon,
       active: isMarkActive(schema.marks.em),
+    },
+    {
+      name: "underline",
+      tooltip: "Underline",
+      icon: () => <UnderlineIcon size={24} color="#fff" />,
+      active: isMarkActive(schema.marks.underline),
     },
     {
       name: "strikethrough",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4609,6 +4609,13 @@ react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-icons@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.10.0.tgz#6c217a2dde2e8fa8d293210023914b123f317297"
+  integrity sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==
+  dependencies:
+    camelcase "^5.0.0"
+
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Description
`_text_` _text_ 형식을 이용해서 underline을 지정할 수 있도록 수정합니다.
- underline extension mark 추가
- Tooltip에 Underline 기능 추가
- italic에서 사용하던 `_text_` 형식을 제거합니다.

![image](https://user-images.githubusercontent.com/6657724/89261654-62758300-d669-11ea-94ca-fb058d7e1a38.png)

## TODOs
- [x] Tooltip Menu에 underline 기능 추가